### PR TITLE
fix: withdrawal issues for type 1 validator and balance lowest than 1 GNO / 32 ETH

### DIFF
--- a/src/components/Consolidate.tsx
+++ b/src/components/Consolidate.tsx
@@ -24,7 +24,7 @@ export default function Consolidate({ network, address }: ConsolidateProps) {
 	const { consolidateValidators, callStatusData } = useConsolidateValidatorsBatch(
 		network.consolidateAddress,
 	);
-	const { withdrawalValidators } = useWithdraw(network.withdrawalAddress);
+	const { withdrawalValidators, computeWithdrawals } = useWithdraw(network);
 
 	const { validators, loading } = useBeaconValidators(network, address);
 
@@ -75,6 +75,7 @@ export default function Consolidate({ network, address }: ConsolidateProps) {
 						}}
 						network={network}
 						goToStep={() => setState((prev) => ({ ...prev, step: Steps.SUMMARY }))}
+						computeWithdrawals={computeWithdrawals}
 					/>
 				);
 			case Steps.SUMMARY:

--- a/src/components/ConsolidateAggregate.tsx
+++ b/src/components/ConsolidateAggregate.tsx
@@ -8,7 +8,7 @@ import { NetworkConfig } from '../constants/networks';
 import { ValidatorInfo } from '../types/validators';
 import { Filter } from './Filter';
 import { ValidatorItem } from './ValidatorItem';
-import { Withdrawal } from '../hooks/useWithdraw';
+import { Withdrawal } from '../types/validators';
 import { ConsolidationSummary } from './ConsolidationSummary';
 import WithdrawBatch from './WithdrawBatch';
 interface ConsolidateSelectProps {
@@ -17,12 +17,14 @@ interface ConsolidateSelectProps {
 	withdrawalValidators: (withdrawal: Withdrawal[]) => Promise<void>;
 	network: NetworkConfig;
 	goToStep: () => void;
+	computeWithdrawals: (validators: ValidatorInfo[], amountToWithdraw: number, totalValidatorBalance: number, preventExit: boolean) => { withdrawals: Withdrawal[], exits: ValidatorInfo[], withdrawalsAmount: number };
 }
 
 export function ConsolidateAggregate({
 	validators,
 	consolidateValidators,
 	withdrawalValidators,
+	computeWithdrawals,
 	network,
 }: ConsolidateSelectProps) {
 	const targetBalance = network.cl.maxBalance * 0.625;
@@ -82,7 +84,7 @@ export function ConsolidateAggregate({
 			<p className="font-bold">Your validators</p>
 			<div className="flex items-center  w-full">
 				<p className="text-sm text-gray-500 mr-2">Balance: {totalBalance} GNO</p>
-				<WithdrawBatch validators={compoundingValidatorsActive} totalBalance={totalBalance} withdrawalValidators={withdrawalValidators} />
+				<WithdrawBatch validators={compoundingValidatorsActive} totalBalance={totalBalance} withdrawalValidators={withdrawalValidators} computeWithdrawals={computeWithdrawals} />
 			</div>
 
 			{/* FILTER */}

--- a/src/components/ConsolidationSummary.tsx
+++ b/src/components/ConsolidationSummary.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef } from 'react';
-import { Consolidation } from '../hooks/useConsolidate';
+import { Consolidation } from '../types/validators';
+import { formatEther } from 'viem';
 
 interface ConsolidationSummaryProps {
     consolidations: Consolidation[];
@@ -60,7 +61,7 @@ export function ConsolidationSummary({ consolidations, consolidateValidators }: 
                                     <tr key={i}>
                                         <td>{c.sourceIndex}</td>
                                         <td>{c.targetIndex}</td>
-                                        <td>{c.sourceBalance + c.targetBalance} GNO</td>
+                                        <td>{formatEther(c.sourceBalance + c.targetBalance)} GNO</td>
                                         <td>{c.sourceIndex === c.targetIndex && (
                                             <p className="text-warning text-xs">Self consolidation</p>
                                         )}</td>

--- a/src/components/ConsolidationSummary.tsx
+++ b/src/components/ConsolidationSummary.tsx
@@ -11,8 +11,8 @@ const BATCH_SIZE = 200;
 export function ConsolidationSummary({ consolidations, consolidateValidators }: ConsolidationSummaryProps) {
     const [currentBatchIndex, setCurrentBatchIndex] = useState(0);
 
-    
-  const dialogRef = useRef<HTMLDialogElement>(null);
+
+    const dialogRef = useRef<HTMLDialogElement>(null);
 
     const batches = useMemo(() => {
         const batchCount = Math.ceil(consolidations.length / BATCH_SIZE);

--- a/src/components/ValidatorItem.tsx
+++ b/src/components/ValidatorItem.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { computeSelfConsolidations, Consolidation } from '../hooks/useConsolidate';
-import { ValidatorInfo, Withdrawal } from '../types/validators';
+import { computeSelfConsolidations } from '../hooks/useConsolidate';
+import { Consolidation, ValidatorInfo, Withdrawal } from '../types/validators';
 import { ValidatorBadge } from './ValidatorBadge';
 import Withdraw from './Withdraw';
+import { formatEther } from 'viem';
 
 interface ValidatorItemProps {
 	validator: ValidatorInfo;
@@ -26,7 +27,7 @@ export function ValidatorItem({
 			<td>
 				<ValidatorBadge filterStatus={validator.filterStatus} status={validator.status} />
 			</td>
-			<td>{validator.balanceEth} GNO</td>
+			<td>{formatEther(validator.balanceEth)} GNO</td>
 
 			<td className="min-w-24">
 				{validator.filterStatus === 'active' && (

--- a/src/components/ValidatorItem.tsx
+++ b/src/components/ValidatorItem.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { computeSelfConsolidations, Consolidation } from '../hooks/useConsolidate';
-import { Withdrawal } from '../hooks/useWithdraw';
-import { ValidatorInfo } from '../types/validators';
+import { ValidatorInfo, Withdrawal } from '../types/validators';
 import { ValidatorBadge } from './ValidatorBadge';
 import Withdraw from './Withdraw';
 

--- a/src/components/ValidatorItem.tsx
+++ b/src/components/ValidatorItem.tsx
@@ -29,25 +29,35 @@ export function ValidatorItem({
 			</td>
 			<td>{validator.balanceEth} GNO</td>
 
-			<td>
-				<div className={`flex rounded-md max-w-fit transition-all duration-300 ${showActions ? 'bg-base-200' : ''}`}>
-					<button className="btn btn-ghost btn-circle btn-sm" onClick={() => setShowActions(!showActions)}>
-						<img src={showActions ? "/xmark.svg" : "/ellipsis-vertical.svg"} alt="Actions" className="w-5 h-5" />
-					</button>
-					{showActions && (
-						<>
-							<button disabled={true} className="btn btn-ghost btn-circle btn-sm"><img src="/deposit.svg" alt="Deposit" className="w-4 h-4" /></button>
-							<Withdraw validator={validator} withdrawalValidators={withdrawalValidators} />
-							{validator.type === 1 && (
-								<button
-									className="btn btn-ghost btn-circle btn-sm"
-									onClick={() => consolidateValidators(computeSelfConsolidations([validator]))}
-								>
-									<img src="/upgrade.svg" alt="Upgrade" className="w-5 h-5" />
-								</button>
-							)}
-						</>
-					)} </div>
+			<td className="min-w-24">
+				{validator.filterStatus === 'active' && (
+					<div className={`flex rounded-md max-w-fit transition-all duration-300 ${showActions ? 'bg-base-200' : ''}`}>
+						<button className="btn btn-ghost btn-circle btn-sm" onClick={() => setShowActions(!showActions)}>
+							<img src={showActions ? "/xmark.svg" : "/ellipsis-vertical.svg"} alt="Actions" className="w-5 h-5" />
+						</button>
+						{showActions && (
+							<>
+								{/* <div className="tooltip" data-tip="Deposit">
+									<button disabled={true} className="btn btn-ghost btn-circle btn-sm"><img src="/deposit.svg" alt="Deposit" className="w-4 h-4" /></button>
+								</div> */}
+								{validator.type === 1 && (
+									<div className="tooltip" data-tip="Upgrade">
+										<button
+											className="btn btn-ghost btn-circle btn-sm"
+											onClick={() => consolidateValidators(computeSelfConsolidations([validator]))}
+										>
+											<img src="/upgrade.svg" alt="Upgrade" className="w-5 h-5" />
+										</button>
+									</div>
+								)}
+
+								{validator.type === 2 && (
+									<div className="tooltip" data-tip="Withdraw">
+										<Withdraw validator={validator} withdrawalValidators={withdrawalValidators} />
+									</div>
+								)}
+							</>
+						)} </div>)}
 			</td>
 		</tr>
 	);

--- a/src/components/Withdraw.tsx
+++ b/src/components/Withdraw.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { ValidatorInfo, Withdrawal } from "../types/validators";
+import { formatEther, parseEther } from "viem";
 
 
 interface WithdrawProps {
@@ -10,7 +11,7 @@ interface WithdrawProps {
 export default function Withdraw({ validator, withdrawalValidators }: WithdrawProps) {
 
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState<number>(0);
 
   return (
     <>
@@ -23,15 +24,15 @@ export default function Withdraw({ validator, withdrawalValidators }: WithdrawPr
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box">
           <h3 className="text-lg font-bold">Validator {validator.index}</h3>
-          <p className="text-sm text-gray-500">Balance: {validator.balanceEth} GNO</p>
+          <p className="text-sm text-gray-500">Balance: {formatEther(validator.balanceEth)} GNO</p>
           <fieldset className="fieldset mt-2 w-full gap-y-2">
-            <legend className="fieldset-legend">Withdraw amount <button className="btn btn-xs" onClick={() => setAmount(validator.balanceEth)}>Max</button></legend>
+            <legend className="fieldset-legend">Withdraw amount <button className="btn btn-xs" onClick={() => setAmount(Number(formatEther(validator.balanceEth)))}>Max</button></legend>
             <input
               type="number"
               placeholder="Type here"
               className="input input-primary input-sm w-full"
               name="amount"
-              max={validator.balanceEth}
+              max={formatEther(validator.balanceEth)}
               value={amount}
               onChange={(e) => setAmount(Number(e.target.value))}
             />
@@ -42,10 +43,10 @@ export default function Withdraw({ validator, withdrawalValidators }: WithdrawPr
               withdrawalValidators([
                 {
                   pubkey: validator.pubkey,
-                  amount: amount,
+                  amount: parseEther(amount.toString()),
                 },
               ])}>
-              {amount === validator.balanceEth ? 'Exit validator'  : 'Withdraw ' + amount + ' GNO'}
+              {amount === Number(formatEther(validator.balanceEth)) ? 'Exit validator'  : 'Withdraw ' + amount + ' GNO'}
             </button>
           </div>
         </div>

--- a/src/components/Withdraw.tsx
+++ b/src/components/Withdraw.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
-import { ValidatorInfo } from "../types/validators";
-import { Withdrawal } from "../hooks/useWithdraw";
+import { ValidatorInfo, Withdrawal } from "../types/validators";
 
 
 interface WithdrawProps {

--- a/src/components/WithdrawBatch.tsx
+++ b/src/components/WithdrawBatch.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useRef, useState } from "react";
 import { ValidatorInfo } from "../types/validators";
 import { Withdrawal } from "../types/validators";
+import { formatEther, parseEther } from "viem";
 
 
 interface WithdrawProps {
   validators: ValidatorInfo[];
-  totalBalance: number;
+  totalBalance: bigint;
   withdrawalValidators: (withdrawal: Withdrawal[]) => Promise<void>;
-  computeWithdrawals: (validators: ValidatorInfo[], amountToWithdraw: number, totalValidatorBalance: number, preventExit: boolean) => { withdrawals: Withdrawal[], exits: ValidatorInfo[], withdrawalsAmount: number };
+  computeWithdrawals: (validators: ValidatorInfo[], amountToWithdraw: bigint, totalValidatorBalance: bigint, preventExit: boolean) => { withdrawals: Withdrawal[], exits: ValidatorInfo[], withdrawalsAmount: bigint };
 }
 
 export default function WithdrawBatch({ validators, totalBalance, withdrawalValidators, computeWithdrawals }: WithdrawProps) {
@@ -16,7 +17,7 @@ export default function WithdrawBatch({ validators, totalBalance, withdrawalVali
   const [amount, setAmount] = useState(0);
   const [preventExit, setPreventExit] = useState(true);
 
-  const { withdrawals, exits, withdrawalsAmount } = useMemo(() => computeWithdrawals(validators, amount, totalBalance, preventExit), [validators, amount, totalBalance, preventExit]);
+  const { withdrawals, exits, withdrawalsAmount } = useMemo(() => computeWithdrawals(validators, parseEther(amount.toString()), totalBalance, preventExit), [validators, amount, totalBalance, preventExit]);
   return (
     <>
       <button
@@ -29,9 +30,9 @@ export default function WithdrawBatch({ validators, totalBalance, withdrawalVali
       <dialog ref={dialogRef} className="modal">
         <div className="modal-box">
           <h3 className="text-lg font-bold">Batch withdraw</h3>
-          <p className="text-sm text-gray-500">Balance: {totalBalance} GNO</p>
+          <p className="text-sm text-gray-500">Balance: {formatEther(totalBalance)} GNO</p>
           <fieldset className="fieldset mt-2 w-full gap-y-2">
-            <legend className="fieldset-legend">Withdraw amount <button className="btn btn-xs" onClick={() => setAmount(totalBalance)}>Max</button></legend>
+            <legend className="fieldset-legend">Withdraw amount <button className="btn btn-xs" onClick={() => setAmount(Number(formatEther(totalBalance)))}>Max</button></legend>
             <div className="flex items-center gap-x-2">
               <input type="checkbox" className="checkbox checkbox-xs" checked={preventExit} onChange={() => setPreventExit(!preventExit)} />
               <p className="text-sm text-gray-500">Prevent exit</p>
@@ -41,7 +42,7 @@ export default function WithdrawBatch({ validators, totalBalance, withdrawalVali
               placeholder="Type here"
               className="input input-primary input-sm w-full"
               name="amount"
-              max={totalBalance}
+              max={formatEther(totalBalance)}
               value={amount}
               onChange={(e) => setAmount(Number(e.target.value))}
             />
@@ -60,7 +61,7 @@ export default function WithdrawBatch({ validators, totalBalance, withdrawalVali
           <div className="mt-8 flex w-full justify-end">
             <button className="btn btn-primary" disabled={withdrawals.length === 0} onClick={() =>
               withdrawalValidators(withdrawals)}>
-              {'Withdraw ' + withdrawalsAmount.toFixed(5) + ' GNO'}
+              {'Withdraw ' + Number(formatEther(withdrawalsAmount)).toFixed(2) + ' GNO'}
             </button>
           </div>
         </div>

--- a/src/components/WithdrawBatch.tsx
+++ b/src/components/WithdrawBatch.tsx
@@ -1,15 +1,16 @@
 import { useMemo, useRef, useState } from "react";
 import { ValidatorInfo } from "../types/validators";
-import { computeWithdrawals, Withdrawal } from "../hooks/useWithdraw";
+import { Withdrawal } from "../types/validators";
 
 
 interface WithdrawProps {
   validators: ValidatorInfo[];
   totalBalance: number;
   withdrawalValidators: (withdrawal: Withdrawal[]) => Promise<void>;
+  computeWithdrawals: (validators: ValidatorInfo[], amountToWithdraw: number, totalValidatorBalance: number, preventExit: boolean) => { withdrawals: Withdrawal[], exits: ValidatorInfo[], withdrawalsAmount: number };
 }
 
-export default function WithdrawBatch({ validators, totalBalance, withdrawalValidators }: WithdrawProps) {
+export default function WithdrawBatch({ validators, totalBalance, withdrawalValidators, computeWithdrawals }: WithdrawProps) {
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [amount, setAmount] = useState(0);

--- a/src/hooks/useBeaconValidators.ts
+++ b/src/hooks/useBeaconValidators.ts
@@ -29,7 +29,6 @@ export function useBeaconValidators(network: NetworkConfig, address: Address) {
 				}
 
 				const json = await res.json();
-				console.log(json.data);
 				const data: BeaconChainResponse[] = json.data;
 
 				const filtered: ValidatorInfo[] = data
@@ -136,8 +135,6 @@ const fetchValidatorDetailsBatch = async (network: NetworkConfig, pubkeys: strin
 	const body: {
 		data: APIValidatorDetailsResponse[] | APIValidatorDetailsResponse;
 	} = await resp.json();
-
-	console.log(body);
 
 	const rows = Array.isArray(body.data) ? body.data : [body.data];
 

--- a/src/hooks/useBeaconValidators.ts
+++ b/src/hooks/useBeaconValidators.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Address } from 'viem';
+import { Address, parseGwei } from 'viem';
 import { NetworkConfig } from '../constants/networks';
 import { APIValidatorDetailsResponse, APIValidatorsResponse } from '../types/api';
 import { ValidatorIndex, ValidatorInfo } from '../types/validators';
@@ -47,7 +47,7 @@ export function useBeaconValidators(network: NetworkConfig, address: Address) {
 						return ({
 							index: Number(v.index),
 							pubkey: v.validator.pubkey,
-							balanceEth: Number(v.validator.effective_balance) / 1e9 / network.cl.multiplier,
+							balanceEth: parseGwei(v.validator.effective_balance.toString()) / BigInt(network.cl.multiplier),
 							withdrawal_credentials: address,
 							type: creds.startsWith('0x02') ? 2 : creds.startsWith('0x01') ? 1 : 0,
 							filterStatus: filterStatus,
@@ -147,7 +147,7 @@ const fetchValidatorDetailsBatch = async (network: NetworkConfig, pubkeys: strin
 		return {
 			index: d.validatorindex,
 			pubkey: d.pubkey as Address,
-			balanceEth: d.effectivebalance / network.cl.multiplier / 1e9,
+			balanceEth: parseGwei(d.effectivebalance.toString()) / BigInt(network.cl.multiplier),
 			withdrawal_credentials: address,
 			type: creds.startsWith('0x02') ? 2 : 1,
 			filterStatus: filterStatus,

--- a/src/hooks/useConsolidate.ts
+++ b/src/hooks/useConsolidate.ts
@@ -18,8 +18,6 @@ interface ComputedConsolidation {
 	targets: Set<number>;
 }
 
-// TODO: Improve this. Right now the balances are rounded to the nearest integer,
-// which is not ideal but at least works closer to what one would expect.
 export function computeConsolidations(
 	compounding: ValidatorInfo[],
 	type1: ValidatorInfo[],

--- a/src/hooks/useConsolidate.ts
+++ b/src/hooks/useConsolidate.ts
@@ -1,16 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useCallsStatus, useSendCalls, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi';
 import { Address, concat, parseEther } from 'viem';
-import { ValidatorInfo } from '../types/validators';
-
-export interface Consolidation {
-	sourceIndex: number;
-	sourceKey: Address;
-	sourceBalance: number;
-	targetIndex: number;
-	targetKey: Address;
-	targetBalance: number;
-}
+import { Consolidation, ValidatorInfo } from '../types/validators';
 
 interface ComputedConsolidation {
 	consolidations: Consolidation[];
@@ -21,7 +12,7 @@ interface ComputedConsolidation {
 export function computeConsolidations(
 	compounding: ValidatorInfo[],
 	type1: ValidatorInfo[],
-	chunkSize: number
+	chunkSize: bigint
 ): ComputedConsolidation {
 	const consolidations: Consolidation[] = []
 	const skippedValidators: ValidatorInfo[] = []
@@ -48,7 +39,7 @@ export function computeConsolidations(
 				sourceBalance: target.balanceEth,
 				targetIndex: target.index,
 				targetKey: target.pubkey,
-				targetBalance: 0,
+				targetBalance: 0n,
 			})
 		}
 
@@ -147,7 +138,7 @@ export function computeSelfConsolidations(
 	const selfConsolidations: Consolidation[] = [];
 
 	for (const v of validators) {
-		selfConsolidations.push({ sourceIndex: v.index, sourceKey: v.pubkey, sourceBalance: 1, targetIndex: v.index, targetKey: v.pubkey, targetBalance: 0 });
+		selfConsolidations.push({ sourceIndex: v.index, sourceKey: v.pubkey, sourceBalance: 1n, targetIndex: v.index, targetKey: v.pubkey, targetBalance: 0n });
 	}
 
 	return selfConsolidations;

--- a/src/hooks/useWithdraw.ts
+++ b/src/hooks/useWithdraw.ts
@@ -1,53 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useCallsStatus, useSendCalls, useSendTransaction, useWaitForTransactionReceipt } from 'wagmi';
 import { Address, encodePacked, parseEther, parseGwei } from 'viem';
-import { ValidatorInfo } from '../types/validators';
+import { ValidatorInfo, Withdrawal } from '../types/validators';
+import { NetworkConfig } from '../constants/networks';
 
-export interface Withdrawal {
-	pubkey: Address;
-	amount: number;
-}
-
-export function computeWithdrawals(
-	validators: ValidatorInfo[],
-	amountToWithdraw: number,
-	totalValidatorBalance: number,
-	preventExit = true
-): { withdrawals: Withdrawal[], exits: ValidatorInfo[], withdrawalsAmount: number } {
-	if (totalValidatorBalance === 0 || amountToWithdraw <= 0) {
-		return { withdrawals: [], exits: [], withdrawalsAmount: 0 };
-	}
-
-	const exitBuffer = preventExit ? 0.01 : 0;
-	const eligibleValidators = validators.filter(v => v.balanceEth > exitBuffer);
-
-	const withdrawals: Withdrawal[] = [];
-	const exits: ValidatorInfo[] = [];
-
-	for (const v of eligibleValidators) {
-		const maxWithdrawable = v.balanceEth - exitBuffer;
-		const proportionalAmount = (v.balanceEth / totalValidatorBalance) * amountToWithdraw;
-		const rawAmount = Math.min(proportionalAmount, maxWithdrawable);
-
-		if (rawAmount > 0) {
-			withdrawals.push({ pubkey: v.pubkey, amount: rawAmount });
-
-			if (!preventExit && rawAmount === v.balanceEth) {
-				exits.push(v);
-			}
-		}
-	}
-
-	return {
-		withdrawals,
-		exits,
-		withdrawalsAmount: withdrawals.reduce((sum, w) => sum + w.amount, 0),
-	};
-}
-
-
-
-export function useWithdraw(contract: Address) {
+export function useWithdraw(network: NetworkConfig) {
 	const { data: hash, sendCalls, status } = useSendCalls();
 	const { data, sendTransaction } = useSendTransaction();
 	const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
@@ -64,6 +21,46 @@ export function useWithdraw(contract: Address) {
 
 	const lastBatchRef = useRef<Withdrawal[] | null>(null)
 
+	const computeWithdrawals = useCallback(
+		(validators: ValidatorInfo[], amountToWithdraw: number, totalValidatorBalance: number, preventExit = true) => {
+			if (totalValidatorBalance === 0 || amountToWithdraw <= 0) {
+				return { withdrawals: [], exits: [], withdrawalsAmount: 0 };
+			}
+
+			const exitBuffer = preventExit ? network.cl.minBalance : 0;
+			const eligibleValidators = validators.filter(v => v.balanceEth > exitBuffer);
+
+			const withdrawals: Withdrawal[] = [];
+			const exits: ValidatorInfo[] = [];
+
+			for (const v of eligibleValidators) {
+				const maxWithdrawable = v.balanceEth - exitBuffer;
+				const proportionalAmount = (v.balanceEth / totalValidatorBalance) * amountToWithdraw;
+				let rawAmount = Math.min(proportionalAmount, maxWithdrawable);
+
+				if (!preventExit) {
+					const leftover = v.balanceEth - rawAmount;
+					if (leftover > 0 && leftover < network.cl.minBalance) {
+					  rawAmount = v.balanceEth;
+					}
+				  }
+
+				if (rawAmount > 0) {
+					withdrawals.push({ pubkey: v.pubkey, amount: rawAmount });
+
+					if (!preventExit && rawAmount === v.balanceEth) {
+						exits.push(v);
+					}
+				}
+			}
+
+			return {
+				withdrawals,
+				exits,
+				withdrawalsAmount: withdrawals.reduce((sum, w) => sum + w.amount, 0),
+			};
+		}, [network]);
+
 	const withdrawalValidators = useCallback(
 		(withdrawal: Withdrawal[]) => {
 			if (withdrawal.length === 0) {
@@ -73,7 +70,7 @@ export function useWithdraw(contract: Address) {
 
 			const calls = withdrawal.map(({ pubkey, amount }) => (
 				{
-					to: contract,
+					to: network.withdrawalAddress,
 					data: encodePacked(
 						["bytes", "uint64"],
 						[
@@ -85,15 +82,16 @@ export function useWithdraw(contract: Address) {
 				}))
 			sendCalls({ calls, capabilities: {} })
 		},
-		[contract, sendCalls],
+		[network, sendCalls],
 	)
+
 
 	useEffect(() => {
 		if (status === 'error' && lastBatchRef.current) {
 			console.warn('Batch failed – falling back to individual txs')
 
 			const calls = lastBatchRef.current.map(({ pubkey, amount }) => ({
-				to: contract,
+				to: network.withdrawalAddress,
 				data: encodePacked(
 					["bytes", "uint64"],
 					[
@@ -118,7 +116,7 @@ export function useWithdraw(contract: Address) {
 				console.error('Fallback submission error', err)
 			})
 		}
-	}, [status, contract, sendTransaction])
+	}, [status, network, sendTransaction])
 
-	return { withdrawalValidators, callStatusData, isConfirming, isConfirmed };
+	return { withdrawalValidators, callStatusData, isConfirming, isConfirmed, computeWithdrawals };
 }

--- a/src/hooks/useWithdraw.ts
+++ b/src/hooks/useWithdraw.ts
@@ -23,7 +23,7 @@ export function useWithdraw(network: NetworkConfig) {
 
 	const computeWithdrawals = useCallback(
 		(validators: ValidatorInfo[], amountToWithdraw: bigint, totalValidatorBalance: bigint, preventExit = true) => {
-			if (totalValidatorBalance === 0n || amountToWithdraw <= 0) {
+			if (totalValidatorBalance === 0n || amountToWithdraw <= 0n) {
 				return { withdrawals: [], exits: [], withdrawalsAmount: 0n };
 			}
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,6 +20,7 @@ export interface APIValidatorDetailsResponse {
     activationeligibilityepoch: number;
     activationepoch: number;
     balance: number;
+    // in gwei
     effectivebalance: number;
     exitepoch: number;
     lastattestationslot: number;

--- a/src/types/beacon.ts
+++ b/src/types/beacon.ts
@@ -8,6 +8,7 @@ export interface BeaconChainResponse {
     validator: {
         activation_eligibility_epoch: number;
         activation_epoch: number;
+        // in gwei
         effective_balance: number;
         exit_epoch: number;
         pubkey: Address;

--- a/src/types/validators.ts
+++ b/src/types/validators.ts
@@ -21,3 +21,8 @@ export interface ValidatorIndex {
     pubkey: Address;
     index: number;
 }
+
+export interface Withdrawal {
+	pubkey: Address;
+	amount: number;
+}

--- a/src/types/validators.ts
+++ b/src/types/validators.ts
@@ -10,7 +10,7 @@ export enum FilterStatus {
 export interface ValidatorInfo {
     index: number;
     pubkey: Address;
-    balanceEth: number;
+    balanceEth: bigint;
     withdrawal_credentials: Address;
     type: number;
     status: ValidatorStatus;
@@ -24,5 +24,14 @@ export interface ValidatorIndex {
 
 export interface Withdrawal {
 	pubkey: Address;
-	amount: number;
+	amount: bigint;
+}
+
+export interface Consolidation {
+	sourceIndex: number;
+	sourceKey: Address;
+	sourceBalance: bigint;
+	targetIndex: number;
+	targetKey: Address;
+	targetBalance: bigint;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tooltips for "Upgrade" and "Withdraw" buttons in the validator actions menu.
  - Action buttons for validators are now shown only when the validator is active and according to validator type.
  - Introduced a new withdrawal computation function passed across components for consistent withdrawal handling.
  - Balances and amounts are now displayed in formatted ether units for improved readability.

- **Bug Fixes**
  - Improved withdrawal calculations to better handle minimum balance requirements and prevent leaving small leftover balances.

- **Style**
  - Refined layout for action buttons in the validator list for better clarity.

- **Chores**
  - Removed debug console logs and outdated comments for cleaner code.
  - Updated data types from numbers to bigints for accurate balance calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->