### PR TITLE
fix: format correctly withdrawal amount

### DIFF
--- a/src/components/Withdraw.tsx
+++ b/src/components/Withdraw.tsx
@@ -51,7 +51,7 @@ export default function Withdraw({ validator }: WithdrawProps) {
                   amount: amount === validator.balanceEth ? 0n : amount,
                 },
               ])}>
-              {amount === validator.balanceEth ? 'Exit validator'  : 'Withdraw ' + amount + ' GNO'}
+              {amount === validator.balanceEth ? 'Exit validator'  : 'Withdraw ' + formatEther(amount) + ' GNO'}
             </button>
           </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the withdrawal button label to display the withdrawal amount in a user-friendly decimal format with "GNO" units. The label for withdrawing the full balance remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->