### PR TITLE
Fix local development for Safe Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ pnpm install
 
 ### Running the Development Server
 
+Copy the `.env.example` file to `.env` and fill in the values.
+
 Start the app locally:
 
 ```bash
 pnpm dev
 ```
 
-The app will be available at [http://localhost:5173](http://localhost:5173).
+The app will be available at [http://localhost:3000](http://localhost:3000).
 
 ### Building for Production
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	async headers() {
+		return [
+			{
+				source: '/manifest\\.json',
+				headers: [
+					{ key: 'Access-Control-Allow-Origin', value: '*' },
+					{ key: 'Access-Control-Allow-Methods', value: 'GET' },
+					{
+						key: 'Access-Control-Allow-Headers',
+						value: 'X-Requested-With, Content-Type, Authorization',
+					},
+				],
+			},
+		];
+	},
 };
 
 export default nextConfig;


### PR DESCRIPTION
In order for the Safe App to be accepted when deployed on localhost, the `manifest.json` needs to return CORS headers correctly. This hase been done for the vercel deployment in `vercel.json`. This PR adds the same headers for the local nextjs deployment.

I also corrected some parts of the README that seemed outdated.


### Testplan

I was able to load a locally deployed app in the Safe UI