### PR TITLE
Fix/safe atomic tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@tanstack/react-query": "5.90.9",
 		"dotenv": "16.6.1",
 		"lucide-react": "0.544.0",
-		"next": "16.2.3",
+		"next": "16.2.6",
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
 		"react-hot-toast": "2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.544.0
         version: 0.544.0(react@19.2.0)
       next:
-        specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -394,53 +394,53 @@ packages:
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
-  '@next/env@16.2.3':
-    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.3':
-    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.3':
-    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
-    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.3':
-    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.3':
-    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.3':
-    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
-    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.3':
-    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1476,8 +1476,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.2.3:
-    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -2476,30 +2476,30 @@ snapshots:
       '@lit-labs/ssr-dom-shim': 1.5.1
     optional: true
 
-  '@next/env@16.2.3': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.3':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.3':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.3':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.3':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.3':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.3':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/ciphers@1.2.1':
@@ -4226,9 +4226,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@next/env': 16.2.3
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
@@ -4237,14 +4237,14 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/src/app/api/validate-deposit/route.ts
+++ b/src/app/api/validate-deposit/route.ts
@@ -2,14 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateDepositData } from '../../../utils/depositValidation';
 import { NETWORK_CONFIG } from '../../../constants/networks';
 
-export const GRAPHQL_URL = process.env.GRAPHQL_URL;
-
-if (!GRAPHQL_URL) {
-	throw new Error('GRAPHQL_URL is not defined');
-}
+const GRAPHQL_URL = process.env.GRAPHQL_URL;
 
 export async function POST(request: NextRequest) {
 	try {
+		if (!GRAPHQL_URL) {
+			return NextResponse.json(
+				{ error: 'GRAPHQL_URL is not configured on the server.' },
+				{ status: 500 },
+			);
+		}
+
 		const body = await request.json();
 		const { depositDataJson, balance, chainId } = body;
 
@@ -27,7 +30,7 @@ export async function POST(request: NextRequest) {
 			depositDataJson,
 			BigInt(balance),
 			contractConfig,
-			GRAPHQL_URL!,
+			GRAPHQL_URL,
 		);
 
 		return NextResponse.json({

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -28,6 +28,12 @@ interface WalletContextType {
 	isMounted: boolean;
 }
 
+interface AtomicBatchCapability {
+	atomicBatch?: {
+		supported?: boolean;
+	};
+}
+
 const WalletContext = createContext<WalletContextType | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
@@ -45,6 +51,20 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 		query: { enabled: !!account.address },
 	});
 
+
+
+	const chainCapabilities = chainId ? capabilities.data?.[chainId] : undefined;
+
+	// EIP-5792 `supported` means the wallet will execute calls atomically now.
+	const supportsStandardAtomic = chainCapabilities?.atomic?.status === 'supported';
+
+	// Safe Apps Provider currently exposes batching with this shape.
+	const supportsAtomicBatch =  
+		(chainCapabilities as AtomicBatchCapability | undefined)?.atomicBatch?.supported === true;
+
+
+	const canBatch = supportsStandardAtomic || supportsAtomicBatch;
+
 	useEffect(() => {
 		setIsMounted(true);
 	}, []);
@@ -55,9 +75,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 				isConnected: isMounted && account.isConnected,
 				address: account.address,
 			},
-			canBatch:
-				capabilities?.data?.[chainId ?? 0]?.atomic?.status === 'supported' ||
-				capabilities?.data?.[chainId ?? 0]?.atomic?.status === 'ready',
+			canBatch,
 			canBatchLoading: capabilities.isLoading,
 			chainId,
 			chainName,
@@ -71,7 +89,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 			isMounted,
 			account.isConnected,
 			account.address,
-			capabilities?.data,
+			canBatch,
 			capabilities.isLoading,
 			chainId,
 			chainName,

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -43,9 +43,7 @@ export function useTxQueue() {
 
 	const isPending = canBatch
 		? sendCallsStatus === 'pending' ||
-			(!!callsData &&
-				callStatusData?.status !== 'success' &&
-				callStatusData?.status !== 'failure')
+			(!!callsData && callStatusData?.status !== 'success' && callStatusData?.status !== 'failure')
 		: sendTxStatus === 'pending' || (!!txHash && isTxWaiting);
 
 	const isConfirmed = canBatch ? callStatusData?.status === 'success' : isTxConfirmed;
@@ -55,7 +53,8 @@ export function useTxQueue() {
 	return {
 		sendSingle: (call: TransactionCall) =>
 			sendTx({ to: call.to, data: call.data, value: call.value }),
-		sendBatch: (calls: TransactionCall[]) => sendCalls({ calls, capabilities: {} }),
+		sendBatch: (calls: TransactionCall[]) =>
+			sendCalls({ calls, capabilities: {}, forceAtomic: calls.length > 1 }),
 		isPending,
 		isConfirmed,
 		isError,


### PR DESCRIPTION
### Summary

PR for fixing batching tx in consolidation ui. This issue was reported by a user (more details on [lineal](https://linear.app/circlesubi/issue/DAP-1))
[Screencast from 2026-05-12 12-45-53.webm](https://github.com/user-attachments/assets/bfc01544-3bdd-4957-a7fc-9f1ccb208ffa)


### Root Cause

The issue is the code handles a batch tx when it finds the following shape on the Wagmi useCapabilities return:
```
data.<chainId>.chainCapabilities.atomic.status
```

However, Safe returns the following:
```
data.<chainId>.chainCapabilities.atomicBatch.supported = true
```
<img width="2307" height="600" alt="image" src="https://github.com/user-attachments/assets/4d160a1d-3a87-44fd-b6e3-a470c8fb18e3" />

### Fix
Two changes:
* On src/app/api/validate-deposit/route.ts , the changes are to detect a batch transaction
* On src/hooks/useTxQueue.ts, to make the batch transaction atomic, so if one fails, all fail

### Commits
1d941e2c3f7b497c10e7309dbc8e0312e0a44263 small tweak to handle GRAPHQL inside the service and not outside
acfeb81a4b2967ec5af8628a99412972d9742cee actual fix

### Test Evidences
[Screencast from 2026-05-12 12-46-37.webm](https://github.com/user-attachments/assets/8cebb726-29d4-4c87-aed7-e31078e86e3e)

