### PR TITLE
fix: floor partial deposit

### DIFF
--- a/src/components/PartialDeposit.tsx
+++ b/src/components/PartialDeposit.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { formatEther, parseEther } from 'viem';
 import { useWallet } from '../context/WalletContext';
+import { floorToGwei } from '../utils/deposit';
 import useDeposit from '../hooks/useDeposit';
 import { ValidatorInfo } from '../types/validators';
 import { useModal } from '../context/ModalContext';
@@ -37,7 +38,10 @@ export default function PartialDeposit({ validator }: { validator: ValidatorInfo
 			<fieldset className="fieldset mt-2 w-full gap-y-2">
 				<legend className="fieldset-legend">
 					Amount to deposit{' '}
-					<button className="btn btn-xs" onClick={() => setAmount(balance.balance)}>
+					<button
+						className="btn btn-xs"
+						onClick={() => setAmount(floorToGwei(balance.balance))}
+					>
 						Max
 					</button>
 				</legend>
@@ -52,7 +56,7 @@ export default function PartialDeposit({ validator }: { validator: ValidatorInfo
 						if (e.target.value === '') { setAmount(0n); return; }
 						try {
 							const parsed = parseEther(e.target.value);
-							setAmount(parsed > balance.balance ? balance.balance : parsed);
+							setAmount(floorToGwei(parsed > balance.balance ? balance.balance : parsed));
 						} catch {
 							setAmount(0n);
 						 }

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -1,5 +1,6 @@
 export const SECOND_IN_DAY = 86400;
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const GWEI = 10n ** 9n;
 // TODO: EL_FEE is sent as `value` with EIP-7002 (withdrawal) and EIP-7251
 // (consolidation) system-contract calls. The predeploys use a dynamic fee that
 // starts at 1 wei and grows with queue pressure — sending less than the

--- a/src/hooks/useDeposit.ts
+++ b/src/hooks/useDeposit.ts
@@ -5,7 +5,12 @@ import useBalance from './useBalance';
 import { NetworkConfig } from '../types/network';
 import { DepositRequest, DepositDataJson } from '../types/deposit';
 import { CredentialType, ValidatorInfo } from '../types/validators';
-import { buildDepositRoot, generateDepositData, generateSignature } from '../utils/deposit';
+import {
+	buildDepositRoot,
+	floorToGwei,
+	generateDepositData,
+	generateSignature,
+} from '../utils/deposit';
 import DEPOSIT_ABI from '../utils/abis/deposit';
 import ERC677ABI from '../utils/abis/erc677';
 import { TransactionCall } from '../types/transaction';
@@ -130,13 +135,14 @@ function useDeposit(contractConfig: NetworkConfig, address: `0x${string}`) {
 	const buildPartialDepositCalls = useCallback(
 		(amounts: bigint[], validators: ValidatorInfo[]): TransactionCall[] => {
 			if (!contractConfig?.tokenAddress || !contractConfig?.depositAddress) return [];
+			const flooredAmounts = amounts.map(floorToGwei);
 
 			const depositsData = validators.map((validator, index) => {
 				const depositReq: DepositRequest = {
 					pubkey: validator.pubkey as `0x${string}`,
 					withdrawal_credentials: validator.withdrawal_credentials as `0x${string}`,
 					signature: generateSignature(96),
-					amount: amounts[index],
+					amount: flooredAmounts[index],
 				};
 
 				const deposit_data_root = buildDepositRoot(
@@ -160,7 +166,7 @@ function useDeposit(contractConfig: NetworkConfig, address: `0x${string}`) {
 			});
 
 			const data = generateDepositData(depositsData);
-			const totalAmount = amounts.reduce((acc, amt) => acc + amt, 0n);
+			const totalAmount = flooredAmounts.reduce((acc, amt) => acc + amt, 0n);
 			const calls: TransactionCall[] = [];
 
 			if ((allowance ?? 0n) < totalAmount) {

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -1,6 +1,9 @@
 import { concat, sha256, toHex } from 'viem';
 import { BatchDepositData, DepositDataJson } from '../types/deposit';
 import { CredentialType } from '../types/validators';
+import { GWEI } from '../constants/misc';
+
+export const floorToGwei = (wei: bigint): bigint => (wei / GWEI) * GWEI;
 
 export const generateDepositData = (deposits: DepositDataJson[]): BatchDepositData => {
 	if (deposits.length === 0) {
@@ -44,7 +47,7 @@ export function buildDepositRoot(
 	signature: `0x${string}`,
 	stakeAmountWei: bigint, // the value you pass to the contract
 ): `0x${string}` {
-	const amountGwei = (stakeAmountWei * 32n) / 10n ** 9n;
+	const amountGwei = (stakeAmountWei * 32n) / GWEI;
 	const amountLE = toLittleEndian64(amountGwei);
 
 	const pubkeyRoot = sha256(concat([pubkey, `0x${'00'.repeat(16)}`]));


### PR DESCRIPTION
Partial deposits could revert with DepositContract: deposit value not multiple of gwei whenever the stake amount wasn't a multiple of 1 gwei (10⁹ wei). This happened via the Max button (raw on-chain balance) and the batch flow (computePartialDepositAmounts integer division).

Fix: floor amounts to the nearest gwei in buildPartialDepositCalls, the single point where the amount feeds both the on-chain value and the deposit_data_root, and both PartialDeposit and PartialDepositBatch are covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deposit amounts are now rounded down to whole Gwei units, preventing fractional values from being used in partial deposits.
  * The “Max” action now uses the largest valid Gwei-aligned amount instead of the raw balance.
  * Approval and deposit totals now stay aligned with the amount that will actually be submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->